### PR TITLE
gitlab: scan CI/CD YAML in gl scan and add gl cicd scan command

### DIFF
--- a/internal/cmd/gitlab/cicd/cicd.go
+++ b/internal/cmd/gitlab/cicd/cicd.go
@@ -1,6 +1,7 @@
 package cicd
 
 import (
+	"github.com/CompassSecurity/pipeleek/internal/cmd/gitlab/cicd/scan"
 	"github.com/CompassSecurity/pipeleek/internal/cmd/gitlab/cicd/yaml"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,7 @@ func NewCiCdCmd() *cobra.Command {
 	ciCdCmd.PersistentFlags().StringVarP(&gitlabApiToken, "token", "t", "", "GitLab API Token")
 
 	ciCdCmd.AddCommand(yaml.NewYamlCmd())
+	ciCdCmd.AddCommand(scan.NewScanCmd())
 
 	return ciCdCmd
 }

--- a/internal/cmd/gitlab/cicd/scan/scan.go
+++ b/internal/cmd/gitlab/cicd/scan/scan.go
@@ -1,0 +1,136 @@
+package scan
+
+import (
+	"github.com/CompassSecurity/pipeleek/internal/cmd/flags"
+	"github.com/CompassSecurity/pipeleek/pkg/config"
+	"github.com/CompassSecurity/pipeleek/pkg/gitlab/scan"
+	"github.com/CompassSecurity/pipeleek/pkg/logging"
+	"github.com/CompassSecurity/pipeleek/pkg/scanner/detectors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+type ScanOptions struct {
+	config.CommonScanOptions
+	ProjectSearchQuery string
+	Member             bool
+	Repository         string
+	Namespace          string
+	QueueFolder        string
+}
+
+var options = ScanOptions{
+	CommonScanOptions: config.DefaultCommonScanOptions(),
+}
+
+// flagBindings maps CLI flags to configuration keys for binding and testing
+var flagBindings = map[string]string{
+	"url":                      "gitlab.url",
+	"token":                    "gitlab.token",
+	"search":                   "gitlab.cicd.scan.search",
+	"member":                   "gitlab.cicd.scan.member",
+	"repo":                     "gitlab.cicd.scan.repo",
+	"namespace":                "gitlab.cicd.scan.namespace",
+	"owned":                    "gitlab.cicd.scan.owned",
+	"queue":                    "gitlab.cicd.scan.queue",
+	"threads":                  "common.threads",
+	"truffle-hog-verification": "common.trufflehog_verification",
+	"confidence":               "common.confidence_filter",
+	"hit-timeout":              "common.hit_timeout",
+}
+
+func NewScanCmd() *cobra.Command {
+	scanCmd := &cobra.Command{
+		Use:   "scan",
+		Short: "Scan CI/CD YAML configurations for secrets",
+		Long: `Scan the fully compiled .gitlab-ci.yml configuration of accessible projects for secrets.
+
+Unlike "gl scan", this command only fetches and scans each project's merged CI/CD YAML - it does not scan job logs or artifacts.`,
+		Example: `
+# Scan the CI/CD YAML of all accessible projects
+pipeleek gl cicd scan --token glpat-xxxxxxxxxxx --url https://gitlab.example.com
+
+# Scan a single repository
+pipeleek gl cicd scan --token glpat-xxxxxxxxxxx --url https://gitlab.example.com --repo mygroup/myproject
+
+# Scan all repositories in a namespace
+pipeleek gl cicd scan --token glpat-xxxxxxxxxxx --url https://gitlab.example.com --namespace mygroup
+		`,
+		Run: Scan,
+	}
+
+	flags.AddCommonScanFlagsNoArtifacts(scanCmd, &options.CommonScanOptions)
+	scanCmd.Flags().BoolVarP(&options.Owned, "owned", "o", false, "Scan only user owned repositories")
+	scanCmd.Flags().StringVarP(&options.ProjectSearchQuery, "search", "s", "", "Query string for searching projects")
+	scanCmd.Flags().BoolVarP(&options.Member, "member", "m", false, "Scan projects the user is member of")
+	scanCmd.Flags().StringVarP(&options.Repository, "repo", "r", "", "Single repository to scan, format: namespace/repo")
+	scanCmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace to scan (all repos in the namespace will be scanned)")
+	scanCmd.Flags().StringVarP(&options.QueueFolder, "queue", "q", "", "Relative or absolute folderpath where the queue files will be stored. Defaults to system tmp. Non-existing folders will be created.")
+
+	return scanCmd
+}
+
+func Scan(cmd *cobra.Command, args []string) {
+	config.NewCommandSetup(cmd).
+		WithFlagBindings(flagBindings).
+		RequireKeys("gitlab.url", "gitlab.token").
+		MustBind()
+
+	gitlabUrl := config.GetString("gitlab.url")
+	gitlabApiToken := config.GetString("gitlab.token")
+	options.ProjectSearchQuery = config.GetString("gitlab.cicd.scan.search")
+	options.Member = config.GetBool("gitlab.cicd.scan.member")
+	options.Repository = config.GetString("gitlab.cicd.scan.repo")
+	options.Namespace = config.GetString("gitlab.cicd.scan.namespace")
+	options.Owned = config.GetBool("gitlab.cicd.scan.owned")
+	options.QueueFolder = config.GetString("gitlab.cicd.scan.queue")
+	options.MaxScanGoRoutines = config.GetInt("common.threads")
+	options.TruffleHogVerification = config.GetBool("common.trufflehog_verification")
+	options.ConfidenceFilter = config.GetStringSlice("common.confidence_filter")
+
+	if err := config.ValidateURL(gitlabUrl, "GitLab URL"); err != nil {
+		log.Fatal().Err(err).Msg("Invalid GitLab URL")
+	}
+	if err := config.ValidateToken(gitlabApiToken, "GitLab API Token"); err != nil {
+		log.Fatal().Err(err).Msg("Invalid GitLab API Token")
+	}
+	if err := config.ValidateThreadCount(options.MaxScanGoRoutines); err != nil {
+		log.Fatal().Err(err).Msg("Invalid thread count")
+	}
+
+	detectors.SetGitLabURL(gitlabUrl)
+
+	scanOpts, err := scan.InitializeOptions(
+		gitlabUrl,
+		gitlabApiToken,
+		"",
+		options.ProjectSearchQuery,
+		options.Repository,
+		options.Namespace,
+		options.QueueFolder,
+		"0",
+		false,
+		options.Owned,
+		options.Member,
+		options.TruffleHogVerification,
+		0,
+		options.MaxScanGoRoutines,
+		options.ConfidenceFilter,
+		options.HitTimeout,
+	)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed initializing scan options")
+	}
+	scanOpts.CICDYamlOnly = true
+
+	scanner := scan.NewScanner(scanOpts)
+	logging.RegisterStatusHook(func() *zerolog.Event {
+		queueLength := scanner.GetQueueStatus()
+		return log.Info().Int("pendingYamlFiles", queueLength)
+	})
+
+	if err := scanner.Scan(); err != nil {
+		log.Fatal().Err(err).Msg("Scan failed")
+	}
+}

--- a/internal/cmd/gitlab/cicd/scan/scan.go
+++ b/internal/cmd/gitlab/cicd/scan/scan.go
@@ -1,6 +1,9 @@
 package scan
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/CompassSecurity/pipeleek/internal/cmd/flags"
 	"github.com/CompassSecurity/pipeleek/pkg/config"
 	"github.com/CompassSecurity/pipeleek/pkg/gitlab/scan"
@@ -11,17 +14,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ScanOptions struct {
+// scanOptions collects the resolved config values for a single run of the command.
+type scanOptions struct {
 	config.CommonScanOptions
+	GitlabUrl          string
+	GitlabApiToken     string
 	ProjectSearchQuery string
 	Member             bool
 	Repository         string
 	Namespace          string
 	QueueFolder        string
-}
-
-var options = ScanOptions{
-	CommonScanOptions: config.DefaultCommonScanOptions(),
 }
 
 // flagBindings maps CLI flags to configuration keys for binding and testing
@@ -60,64 +62,81 @@ pipeleek gl cicd scan --token glpat-xxxxxxxxxxx --url https://gitlab.example.com
 		Run: Scan,
 	}
 
-	flags.AddCommonScanFlagsNoArtifacts(scanCmd, &options.CommonScanOptions)
-	scanCmd.Flags().BoolVarP(&options.Owned, "owned", "o", false, "Scan only user owned repositories")
-	scanCmd.Flags().StringVarP(&options.ProjectSearchQuery, "search", "s", "", "Query string for searching projects")
-	scanCmd.Flags().BoolVarP(&options.Member, "member", "m", false, "Scan projects the user is member of")
-	scanCmd.Flags().StringVarP(&options.Repository, "repo", "r", "", "Single repository to scan, format: namespace/repo")
-	scanCmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Namespace to scan (all repos in the namespace will be scanned)")
-	scanCmd.Flags().StringVarP(&options.QueueFolder, "queue", "q", "", "Relative or absolute folderpath where the queue files will be stored. Defaults to system tmp. Non-existing folders will be created.")
+	defaultOpts := config.DefaultCommonScanOptions()
+	flags.AddCommonScanFlagsNoArtifacts(scanCmd, &defaultOpts)
+	scanCmd.Flags().BoolP("owned", "o", false, "Scan only user owned repositories")
+	scanCmd.Flags().StringP("search", "s", "", "Query string for searching projects")
+	scanCmd.Flags().BoolP("member", "m", false, "Scan projects the user is member of")
+	scanCmd.Flags().StringP("repo", "r", "", "Single repository to scan, format: namespace/repo")
+	scanCmd.Flags().StringP("namespace", "n", "", "Namespace to scan (all repos in the namespace will be scanned)")
+	scanCmd.Flags().StringP("queue", "q", "", "Relative or absolute folderpath where the queue files will be stored. Defaults to system tmp. Non-existing folders will be created.")
 
 	return scanCmd
 }
 
+// Scan is the named Cobra Run handler; it resolves config into a local options struct and delegates to runScan.
 func Scan(cmd *cobra.Command, args []string) {
 	config.NewCommandSetup(cmd).
 		WithFlagBindings(flagBindings).
 		RequireKeys("gitlab.url", "gitlab.token").
 		MustBind()
 
-	gitlabUrl := config.GetString("gitlab.url")
-	gitlabApiToken := config.GetString("gitlab.token")
-	options.ProjectSearchQuery = config.GetString("gitlab.cicd.scan.search")
-	options.Member = config.GetBool("gitlab.cicd.scan.member")
-	options.Repository = config.GetString("gitlab.cicd.scan.repo")
-	options.Namespace = config.GetString("gitlab.cicd.scan.namespace")
-	options.Owned = config.GetBool("gitlab.cicd.scan.owned")
-	options.QueueFolder = config.GetString("gitlab.cicd.scan.queue")
-	options.MaxScanGoRoutines = config.GetInt("common.threads")
-	options.TruffleHogVerification = config.GetBool("common.trufflehog_verification")
-	options.ConfidenceFilter = config.GetStringSlice("common.confidence_filter")
+	hitTimeoutRaw := config.GetString("common.hit_timeout")
+	hitTimeout, err := time.ParseDuration(hitTimeoutRaw)
+	if err != nil {
+		log.Fatal().Err(fmt.Errorf("invalid hit-timeout %q: %w", hitTimeoutRaw, err)).Msg("Invalid hit timeout")
+	}
 
-	if err := config.ValidateURL(gitlabUrl, "GitLab URL"); err != nil {
+	opts := scanOptions{
+		GitlabUrl:          config.GetString("gitlab.url"),
+		GitlabApiToken:     config.GetString("gitlab.token"),
+		ProjectSearchQuery: config.GetString("gitlab.cicd.scan.search"),
+		Member:             config.GetBool("gitlab.cicd.scan.member"),
+		Repository:         config.GetString("gitlab.cicd.scan.repo"),
+		Namespace:          config.GetString("gitlab.cicd.scan.namespace"),
+		QueueFolder:        config.GetString("gitlab.cicd.scan.queue"),
+		CommonScanOptions: config.CommonScanOptions{
+			Owned:                  config.GetBool("gitlab.cicd.scan.owned"),
+			MaxScanGoRoutines:      config.GetInt("common.threads"),
+			TruffleHogVerification: config.GetBool("common.trufflehog_verification"),
+			ConfidenceFilter:       config.GetStringSlice("common.confidence_filter"),
+			HitTimeout:             hitTimeout,
+		},
+	}
+
+	runScan(opts)
+}
+
+func runScan(opts scanOptions) {
+	if err := config.ValidateURL(opts.GitlabUrl, "GitLab URL"); err != nil {
 		log.Fatal().Err(err).Msg("Invalid GitLab URL")
 	}
-	if err := config.ValidateToken(gitlabApiToken, "GitLab API Token"); err != nil {
+	if err := config.ValidateToken(opts.GitlabApiToken, "GitLab API Token"); err != nil {
 		log.Fatal().Err(err).Msg("Invalid GitLab API Token")
 	}
-	if err := config.ValidateThreadCount(options.MaxScanGoRoutines); err != nil {
+	if err := config.ValidateThreadCount(opts.MaxScanGoRoutines); err != nil {
 		log.Fatal().Err(err).Msg("Invalid thread count")
 	}
 
-	detectors.SetGitLabURL(gitlabUrl)
+	detectors.SetGitLabURL(opts.GitlabUrl)
 
 	scanOpts, err := scan.InitializeOptions(
-		gitlabUrl,
-		gitlabApiToken,
+		opts.GitlabUrl,
+		opts.GitlabApiToken,
 		"",
-		options.ProjectSearchQuery,
-		options.Repository,
-		options.Namespace,
-		options.QueueFolder,
+		opts.ProjectSearchQuery,
+		opts.Repository,
+		opts.Namespace,
+		opts.QueueFolder,
 		"0",
 		false,
-		options.Owned,
-		options.Member,
-		options.TruffleHogVerification,
+		opts.Owned,
+		opts.Member,
+		opts.TruffleHogVerification,
 		0,
-		options.MaxScanGoRoutines,
-		options.ConfidenceFilter,
-		options.HitTimeout,
+		opts.MaxScanGoRoutines,
+		opts.ConfidenceFilter,
+		opts.HitTimeout,
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed initializing scan options")

--- a/internal/cmd/gitlab/cicd/scan/scan_test.go
+++ b/internal/cmd/gitlab/cicd/scan/scan_test.go
@@ -1,5 +1,4 @@
 package scan
-package scan
 
 import (
 	"reflect"

--- a/internal/cmd/gitlab/cicd/scan/scan_test.go
+++ b/internal/cmd/gitlab/cicd/scan/scan_test.go
@@ -1,0 +1,58 @@
+package scan
+package scan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/CompassSecurity/pipeleek/internal/cmd/testutil"
+)
+
+func TestScanCmd_AllDefinedFlagsAreBound(t *testing.T) {
+	cmd := NewScanCmd()
+	testutil.AssertAllFlagsHaveBindings(t, cmd, flagBindings, "url", "token")
+}
+
+func TestNewScanCmd(t *testing.T) {
+	cmd := NewScanCmd()
+	if cmd == nil {
+		t.Fatal("Expected non-nil command")
+	}
+
+	if cmd.Use != "scan" {
+		t.Errorf("Expected Use to be 'scan', got %q", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("Expected non-empty Short description")
+	}
+
+	if reflect.ValueOf(Scan).Pointer() != reflect.ValueOf(cmd.Run).Pointer() {
+		t.Error("Expected cmd.Run to reference the Scan handler")
+	}
+
+	flags := cmd.Flags()
+	for _, name := range []string{
+		"search",
+		"member",
+		"repo",
+		"namespace",
+		"owned",
+		"queue",
+		"threads",
+		"truffle-hog-verification",
+		"confidence",
+		"hit-timeout",
+	} {
+		if flags.Lookup(name) == nil {
+			t.Errorf("Expected flag %q to exist", name)
+		}
+	}
+
+	// This command must not scan artifacts or job logs - only CI/CD YAML.
+	for _, name := range []string{"artifacts", "max-artifact-size", "job-limit", "cookie"} {
+		if flags.Lookup(name) != nil {
+			t.Errorf("Unexpected flag %q on CI/CD-only scan command", name)
+		}
+	}
+}

--- a/pkg/gitlab/scan/pipeline.go
+++ b/pkg/gitlab/scan/pipeline.go
@@ -39,6 +39,8 @@ type ScanOptions struct {
 	QueueFolder            string
 	TruffleHogVerification bool
 	HitTimeout             time.Duration
+	// CICDYamlOnly restricts scanning to the project's merged CI/CD YAML, skipping job logs and artifacts.
+	CICDYamlOnly bool
 }
 
 func ScanGitLabPipelines(options *ScanOptions) {
@@ -94,7 +96,7 @@ func ScanGitLabPipelines(options *ScanOptions) {
 func scanRepository(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	log.Info().Str("repository", options.Repository).Msg("Scanning repository pipelines")
+	log.Info().Str("repository", options.Repository).Msg("Scanning repository " + scanTargetLabel(options))
 
 	project, resp, err := git.Projects.GetProject(options.Repository, &gitlab.GetProjectOptions{})
 	if err != nil {
@@ -120,7 +122,7 @@ func scanRepository(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup
 func scanNamespace(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	log.Info().Str("namespace", options.Namespace).Msg("Scanning namespace pipelines")
+	log.Info().Str("namespace", options.Namespace).Msg("Scanning namespace " + scanTargetLabel(options))
 	group, resp, err := git.Groups.GetGroup(options.Namespace, &gitlab.GetGroupOptions{})
 
 	if err != nil {
@@ -144,7 +146,6 @@ func scanNamespace(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup)
 	}
 
 	err = util.IterateGroupProjects(git, group.ID, projectOpts, func(project *gitlab.Project) error {
-		log.Debug().Str("url", project.WebURL).Msg("Fetch project jobs")
 		getAllJobs(git, project, options)
 		return nil
 	})
@@ -194,7 +195,6 @@ func fetchProjects(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup)
 	}
 
 	err := util.IterateProjects(git, projectOpts, func(project *gitlab.Project) error {
-		log.Debug().Str("url", project.WebURL).Msg("Fetch project jobs")
 		getAllJobs(git, project, options)
 		return nil
 	})
@@ -208,8 +208,28 @@ func fetchProjects(git *gitlab.Client, options *ScanOptions, wg *sync.WaitGroup)
 
 func getAllJobs(git *gitlab.Client, project *gitlab.Project, options *ScanOptions) {
 
+	if options.CICDYamlOnly {
+		log.Debug().Str("url", project.WebURL).Msg("Fetch project CI/CD YAML")
+	} else {
+		log.Debug().Str("url", project.WebURL).Msg("Fetch project jobs")
+	}
+
 	if isUnauthenticatedMode(options) {
+		if options.CICDYamlOnly {
+			return
+		}
 		getAllJobsViaPipelines(git, project, options)
+		return
+	}
+
+	enqueueItem(globQueue, QueueItemCICDYaml, QueueMeta{
+		ProjectId:                int(project.ID),
+		JobWebUrl:                project.WebURL,
+		JobName:                  ".gitlab-ci.yml",
+		ProjectPathWithNamespace: project.PathWithNamespace,
+	}, waitGroup)
+
+	if options.CICDYamlOnly {
 		return
 	}
 
@@ -278,6 +298,14 @@ jobOut:
 
 func isUnauthenticatedMode(options *ScanOptions) bool {
 	return strings.TrimSpace(options.GitlabApiToken) == ""
+}
+
+// scanTargetLabel describes what getAllJobs fetches per project, for accurate progress logging.
+func scanTargetLabel(options *ScanOptions) string {
+	if options.CICDYamlOnly {
+		return "CI/CD YAML"
+	}
+	return "pipelines"
 }
 
 // getAllJobsViaPipelines enqueues jobs by iterating pipelines then their jobs.

--- a/pkg/gitlab/scan/queue.go
+++ b/pkg/gitlab/scan/queue.go
@@ -221,7 +221,7 @@ func analyzeDotenvArtifact(git *gitlab.Client, item QueueItem, options *ScanOpti
 func analyzeCICDYaml(git *gitlab.Client, item QueueItem, options *ScanOptions) {
 	ciCdYml, err := util.FetchCICDYml(git, int64(item.Meta.ProjectId))
 	if err != nil {
-		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed fetching project CI/CD YML")
+		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed fetching project CI/CD YAML")
 		return
 	}
 
@@ -233,7 +233,7 @@ func analyzeCICDYaml(git *gitlab.Client, item QueueItem, options *ScanOptions) {
 		HitTimeout:        options.HitTimeout,
 	})
 	if err != nil {
-		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed detecting secrets in CI/CD YML")
+		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed detecting secrets in CI/CD YAML")
 		return
 	}
 

--- a/pkg/gitlab/scan/queue.go
+++ b/pkg/gitlab/scan/queue.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CompassSecurity/pipeleek/pkg/format"
 	"github.com/CompassSecurity/pipeleek/pkg/httpclient"
 	"github.com/CompassSecurity/pipeleek/pkg/logging"
+	"github.com/CompassSecurity/pipeleek/pkg/gitlab/util"
 	artifactproc "github.com/CompassSecurity/pipeleek/pkg/scan/artifact"
 	"github.com/CompassSecurity/pipeleek/pkg/scan/logline"
 	"github.com/CompassSecurity/pipeleek/pkg/scan/result"
@@ -33,6 +34,7 @@ const (
 	QueueItemJobTrace QueueItemType = "jobTrace"
 	QueueItemArtifact QueueItemType = "artifact"
 	QueueItemDotenv   QueueItemType = "dotenv"
+	QueueItemCICDYaml QueueItemType = "cicdYaml"
 )
 
 type QueueMeta struct {
@@ -113,6 +115,10 @@ func analyzeQueueItem(serializeditem []byte, git *gitlab.Client, options *ScanOp
 
 	if item.Type == QueueItemDotenv {
 		analyzeDotenvArtifact(git, item, options)
+	}
+
+	if item.Type == QueueItemCICDYaml {
+		analyzeCICDYaml(git, item, options)
 	}
 }
 
@@ -210,6 +216,31 @@ func analyzeDotenvArtifact(git *gitlab.Client, item QueueItem, options *ScanOpti
 			"note": "Check artifacts page - dotenv files are only downloadable there",
 		})
 	}
+}
+
+func analyzeCICDYaml(git *gitlab.Client, item QueueItem, options *ScanOptions) {
+	ciCdYml, err := util.FetchCICDYml(git, int64(item.Meta.ProjectId))
+	if err != nil {
+		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed fetching project CI/CD YML")
+		return
+	}
+
+	logResult, err := logline.ProcessLogs([]byte(ciCdYml), logline.ProcessOptions{
+		MaxGoRoutines:     options.MaxScanGoRoutines,
+		VerifyCredentials: options.TruffleHogVerification,
+		BuildURL:          item.Meta.JobWebUrl,
+		JobName:           item.Meta.JobName,
+		HitTimeout:        options.HitTimeout,
+	})
+	if err != nil {
+		log.Debug().Err(err).Int("project", item.Meta.ProjectId).Msg("Failed detecting secrets in CI/CD YML")
+		return
+	}
+
+	result.ReportFindings(logResult.Findings, result.ReportOptions{
+		LocationURL: item.Meta.JobWebUrl,
+		JobName:     item.Meta.JobName,
+	})
 }
 
 func getJobTrace(git *gitlab.Client, projectId int, jobId int, jobWebUrl string, options *ScanOptions) []byte {

--- a/tests/e2e/gitlab/cicd/scan/scan_test.go
+++ b/tests/e2e/gitlab/cicd/scan/scan_test.go
@@ -50,7 +50,7 @@ func TestGLCicdScan_HappyPath(t *testing.T) {
 
 	requests := getRequests()
 	for _, req := range requests {
-		assert.NotContains(t, req.Path, "/jobs/", "Should never fetch job logs or artifacts")
+		assert.NotContains(t, req.Path, "/jobs", "Should never fetch job logs or artifacts")
 		assert.NotContains(t, req.Path, "/pipelines", "Should never list pipelines")
 	}
 

--- a/tests/e2e/gitlab/cicd/scan/scan_test.go
+++ b/tests/e2e/gitlab/cicd/scan/scan_test.go
@@ -1,0 +1,111 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/CompassSecurity/pipeleek/tests/e2e/internal/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGLCicdScan_HappyPath(t *testing.T) {
+	server, getRequests, cleanup := testutil.StartMockServerWithRecording(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v4/projects":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"id": 1, "name": "test-project", "path_with_namespace": "group/test-project"},
+			})
+
+		case "/api/v4/projects/1/ci/lint":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"valid": true,
+				"merged_yaml": "deploy:\n  script:\n    - echo AKIAIOSFODNN7EXAMPLE\n",
+				"warnings": [],
+				"errors": []
+			}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		}
+	})
+	defer cleanup()
+
+	stdout, stderr, exitErr := testutil.RunCLI(t, []string{
+		"gl", "cicd", "scan",
+		"--url", server.URL,
+		"--token", "glpat-test-token-123",
+	}, nil, 10*time.Second)
+
+	assert.Nil(t, exitErr, "Command should succeed")
+	assert.Contains(t, stdout, "AKIAIOSFODNN7EXAMPLE", "Should detect the secret embedded in the CI/CD YAML")
+
+	requests := getRequests()
+	for _, req := range requests {
+		assert.NotContains(t, req.Path, "/jobs/", "Should never fetch job logs or artifacts")
+		assert.NotContains(t, req.Path, "/pipelines", "Should never list pipelines")
+	}
+
+	t.Logf("STDOUT:\n%s", stdout)
+	t.Logf("STDERR:\n%s", stderr)
+}
+
+func TestGLCicdScan_RepoFlag(t *testing.T) {
+	server, getRequests, cleanup := testutil.StartMockServerWithRecording(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v4/projects/group/project", "/api/v4/projects/group%2Fproject":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": 1, "name": "project", "path_with_namespace": "group/project",
+			})
+
+		case "/api/v4/projects/1/ci/lint":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"valid": true, "merged_yaml": "job:\n  script: echo hi\n", "warnings": [], "errors": []}`))
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		}
+	})
+	defer cleanup()
+
+	stdout, _, exitErr := testutil.RunCLI(t, []string{
+		"gl", "cicd", "scan",
+		"--url", server.URL,
+		"--token", "glpat-test",
+		"--repo", "group/project",
+	}, nil, 10*time.Second)
+
+	assert.Nil(t, exitErr, "Command should succeed with --repo flag")
+
+	requests := getRequests()
+	lintRequestFound := false
+	for _, req := range requests {
+		if req.Path == "/api/v4/projects/1/ci/lint" {
+			lintRequestFound = true
+		}
+	}
+	assert.True(t, lintRequestFound, "Should fetch the merged CI/CD YAML for the targeted repository")
+	t.Logf("STDOUT:\n%s", stdout)
+}
+
+func TestGLCicdScan_MissingRequiredFlags(t *testing.T) {
+	stdout, stderr, exitErr := testutil.RunCLI(t, []string{
+		"gl", "cicd", "scan",
+	}, nil, 5*time.Second)
+
+	assert.NotNil(t, exitErr, "Should fail without url/token")
+	output := stdout + stderr
+	assert.Contains(t, output, "gitlab.url", "Should mention missing required url config key")
+}

--- a/tests/e2e/gitlab/scan/scan_test.go
+++ b/tests/e2e/gitlab/scan/scan_test.go
@@ -251,4 +251,57 @@ func TestGitLabScan_FlagVariations(t *testing.T) {
 	}
 }
 
+// TestGitLabScan_ScansCICDYaml verifies the scan command fetches and scans the
+// project's merged .gitlab-ci.yml for secrets via the CI lint API.
+func TestGitLabScan_ScansCICDYaml(t *testing.T) {
+	server, getRequests, cleanup := testutil.StartMockServerWithRecording(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v4/projects":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"id": 1, "name": "test-project", "path_with_namespace": "group/test-project"},
+			})
+
+		case "/api/v4/projects/1/ci/lint":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"valid": true,
+				"merged_yaml": "deploy:\n  script:\n    - echo AKIAIOSFODNN7EXAMPLE\n",
+				"warnings": [],
+				"errors": []
+			}`))
+
+		case "/api/v4/projects/1/pipelines":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+
+		default:
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+		}
+	})
+	defer cleanup()
+
+	stdout, _, exitErr := testutil.RunCLI(t, []string{
+		"gl", "scan",
+		"--url", server.URL,
+		"--token", "glpat-test-token-123",
+	}, nil, 10*time.Second)
+
+	assert.Nil(t, exitErr, "Command should succeed")
+
+	requests := getRequests()
+	lintRequestFound := false
+	for _, req := range requests {
+		if req.Path == "/api/v4/projects/1/ci/lint" {
+			lintRequestFound = true
+			break
+		}
+	}
+	assert.True(t, lintRequestFound, "Should fetch the project's merged CI/CD YAML via the ci/lint endpoint")
+	assert.Contains(t, stdout, "AKIAIOSFODNN7EXAMPLE", "Should detect the secret embedded in the CI/CD YAML")
+}
+
 // TestGitLabEnum tests GitLab enumeration command


### PR DESCRIPTION
- gl scan now also fetches each project's merged .gitlab-ci.yml via the CI lint API and scans it for secrets, in addition to job logs/artifacts
- add new gl cicd scan subcommand that only scans CI/CD YAML (no job logs/artifacts), reusing the existing scan/queue infrastructure via a CICDYamlOnly mode
- add unit and e2e test coverage for both changes